### PR TITLE
Update post_groups.rb

### DIFF
--- a/lib/Jekyll/Itafroma/post_groups.rb
+++ b/lib/Jekyll/Itafroma/post_groups.rb
@@ -5,6 +5,8 @@
 # Copyright: Copyright (c) 2014 Mark Trapp
 # License:: MIT
 
+JEKYLL_MIN_VERSION_3 = Gem::Version.new(Jekyll::VERSION) >= Gem::Version.new('3.0.0') unless defined? JEKYLL_MIN_VERSION_3
+
 module Jekyll
   module Itafroma
     class PostGroupsGenerator < Jekyll::Generator
@@ -24,7 +26,8 @@ module Jekyll
         # Build a hash map based on the specified post attribute ( post attr =>
         # array of posts ) then sort each array in reverse order.
         hash = Hash.new { |hsh, key| hsh[key] = Array.new }
-        site.posts.each do |p|
+        posts = JEKYLL_MIN_VERSION_3 ? site.posts.docs : site.posts
+        posts.each do |p|
           # Skip post if it doesn't have the correct key
           next unless p.data.key? post_key
 


### PR DESCRIPTION
Add compatibility for Jekyll 3.x, avoiding deprecation error:
  Deprecation: Collection#each should be called on the #docs array directly.
  Called by /usr/local/rvm/gems/ruby-2.1.2/gems/jekyll-itafroma-post_groups-0.2.0/lib/jekyll/itafroma/post_groups.rb:27:in `post_key_hash'.

See https://github.com/jekyll/jekyll/issues/4199
